### PR TITLE
Add experimental dotOperators switch to test

### DIFF
--- a/test.nim
+++ b/test.nim
@@ -2,6 +2,8 @@ import nimsl/nimsl
 import nimsl/emulation
 import unittest, times, math
 
+{.experimental: "dotOperators".} # for swizzling
+
 proc fillAlpha(dist: float32): float32 =
     let d = fwidth(dist)
     result = 1.0 - smoothstep(-d, d, dist)


### PR DESCRIPTION
The current Nim behavior is that the experimentals for call/dot operators only need to be enabled at the declaration site, and modules using the operators do not need it enabled. This behavior is changed in https://github.com/nim-lang/Nim/pull/16924. This test does not enable the dotOperators experimental switch (used here for swizzling), making packages CI break for that PR. Adding this switch here does not break the test for previous behavior.