### PR TITLE
Use latest head for variant

### DIFF
--- a/nimsl.nimble
+++ b/nimsl.nimble
@@ -5,7 +5,7 @@ description = "Shaders in Nim"
 license = "MIT"
 
 # Dependencies
-requires "variant"
+requires "variant#HEAD"
 
 # Tests
 const allTests = ["test", "nimsl/private/var_decls"]


### PR DESCRIPTION
This is to make https://github.com/yglukhov/variant/pull/9 register in Nim CI. Alternatively a new release can be tagged in variant.